### PR TITLE
LW-26353 fix for enum deletion audit

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -477,7 +477,12 @@ class LogRevisionsListener implements EventSubscriber
                 continue;
             }
 
-            $params[] = $entityData[$field] ?? null;
+            $param = $entityData[$field] ?? null;
+            if ($param instanceof \BackedEnum) {
+                $param = $param->value;
+            }
+
+            $params[] = $param;
             $types[] = $class->fieldMappings[$field]['type'];
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because we have an error while saving the audit record after the deletion of the origin one.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://lingoda.atlassian.net/browse/LW-26353

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added

### Changed
I implementing getting value from the `\BakedEnum` if the taken from 
UnitOfWorks one is the object. Usually, it happens during the deletion operation

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->